### PR TITLE
fix(rspec-core): make the output field readable for rspec-core 3.10.x

### DIFF
--- a/lib/rspec_sonarqube_formatter.rb
+++ b/lib/rspec_sonarqube_formatter.rb
@@ -3,6 +3,8 @@
 require 'htmlentities'
 
 class RspecSonarqubeFormatter
+  attr_reader :output
+
   ::RSpec::Core::Formatters.register self,
     :start, :stop, :example_group_started, :example_started, :example_passed, :example_failed, :example_pending
 


### PR DESCRIPTION
I tried to use it in a recent project and it's breaking. So I just added the output field as readable to make it work with rspec-core 3.10.x.

```bash
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/home/danilo/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib/rspec/core/formatters.rb:197:in `block in duplicate_formatter_exists?': undefined method `output' for #<RspecSonarqubeFormatter:0x000055c1c7c9cf28 @output=#<File:out/test-report.xml>, @current_file="", @last_failure_index=0> (NoMethodError)
```